### PR TITLE
Julesにtensorflowをアップデートしてもらう

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 *.pyc
 .python-version
 .venv/
-results/*.json

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 .python-version
 .venv/
+results/*.json

--- a/DRBM.py
+++ b/DRBM.py
@@ -103,10 +103,10 @@ class DRBM:
             learninglog.make_log(epoch, "test-error", float(1.-test_accuracy.result()))
             learninglog.make_log(epoch, "test-nloglikelihood", float(test_loss.result()))
 
-            train_loss.reset_states()
-            train_accuracy.reset_states()
-            test_loss.reset_states()
-            test_accuracy.reset_states()
+            train_loss.reset_state()
+            train_accuracy.reset_state()
+            test_loss.reset_state()
+            test_accuracy.reset_state()
     
     def fit_generative(self, train_epoch, data_size, minibatch_size, optimizer, train_ds, gen_drbm, learninglog):
         train_loss = tf.keras.metrics.Mean(name='train_loss')
@@ -132,7 +132,7 @@ class DRBM:
             learninglog.make_log(epoch, "kl-divergence", float(kld))
             learninglog.make_log(epoch, "nloglikelihood", float(train_loss.result()))
 
-            train_loss.reset_states()
+            train_loss.reset_state()
 
     def save(self, filename):
         data_names = ["input_num", "hidden_num", "output_num", "dtype", "activation", "enable_sparse"]

--- a/hidden_marginalize.py
+++ b/hidden_marginalize.py
@@ -40,14 +40,14 @@ class continuous:
         approx_factors_grad = np.array([2/945, 0., -1/45, 0., 1/3, 0.]).astype(input.dtype.as_numpy_dtype())
         ret = tf.where(
             tf.math.abs(input) < 1e-3,
-            tf.math.polyval(approx_factors, input),
+            tf.math.polyval(list(approx_factors), input),
             tf.math.log(2*tf.math.sinh(input)/input)
         )
         @tf.function
         def grad(dy):
             return dy * tf.where(
                 tf.math.abs(input) < 1e-3,
-                tf.math.polyval(approx_factors_grad, input),
+                tf.math.polyval(list(approx_factors_grad), input),
                 (1/tf.math.tanh(input) - 1/input)
             )
         return ret, grad
@@ -75,13 +75,13 @@ class continuous_sparse:
             )
         ret = tf.where(
             tf.abs(x) < 1e-3,
-            tf.math.polyval(approx_factors, x),
+            tf.math.polyval(list(approx_factors), x),
             ret
         )
         def grad(dy):
             r = tf.where(
                 tf.abs(x) < 1e-3,
-                tf.math.polyval(approx_factors_grad, x),
+                tf.math.polyval(list(approx_factors_grad), x),
                 1/tf.tanh(x) - 1/x -1
             )
             grad_ret = dy * ret * r

--- a/train_generative.py
+++ b/train_generative.py
@@ -23,10 +23,12 @@ dtype = config["dtype"]
 
 gen_drbm = DRBM(*config["generative-layers"], **config["generative-args"], dtype=dtype, random_bias=True)
 x_train, y_train = gen_drbm.stick_break(config["datasize"])
-y_train = to_categorical(y_train, dtype=dtype)
+num_classes = tf.cast(tf.reduce_max(y_train) + 1, dtype=tf.int32)
+y_train = to_categorical(y_train, num_classes=num_classes)
+y_train = tf.cast(y_train, dtype=dtype)
 
 train_ds = tf.data.Dataset.from_tensor_slices((x_train, y_train))
-optimizer = tf.keras.optimizers.Adamax(learning_rate=0.002, epsilon=1e-8)
+optimizer = tf.keras.optimizers.Adamax(learning_rate=0.002, epsilon=1e-07)
 
 drbm = DRBM(*config["training-layers"], **config["training-args"], dtype=dtype)
 drbm.fit_generative(args.learning_epoch, config["datasize"], config["minibatch-size"], optimizer, train_ds, gen_drbm, ll)


### PR DESCRIPTION
```
Here's an update on the progress of updating to TensorFlow 2.16.1 and ensuring non-deterministic behavior.

I've made a commit to update the project to be compatible with TensorFlow version 2.16.1.

Key changes include:
- Updated `tf.keras.optimizers.Adamax` initialization in `train_generative.py` to use the current default epsilon value (1e-07).
- Addressed other minor API changes encountered during testing to ensure script functionality with TF 2.16.1 (related to `tf.math.polyval`, `to_categorical` arguments, and Keras metric `reset_state` calls).
- Confirmed that the codebase uses non-deterministic random number generation by default, as no global random seeds are set.
- Added `results/*.json` to `.gitignore` to prevent training log files from being committed.

The training script `train_generative.py` was tested with the command `./train_generative.py ./config/generative/h200/continuous.json 10` and runs successfully.
```